### PR TITLE
Let east work again

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,3 +30,15 @@ lane :apk2 do
     apk: './fastlane/apk2/BanditTheCat.apk'
   )
 end
+
+lane :east do
+  aws_s3(
+    bucket: 'fastlane-plugin-s3-east',
+    region: 'us-east-1',
+    apk: './fastlane/apk2/BanditTheCat.apk'
+  )
+end
+
+after_all do
+  puts Actions.lane_context[SharedValues::S3_HTML_OUTPUT_PATH]
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -25,9 +25,14 @@ fastlane apk1
 fastlane apk2
 ```
 
+### east
+```
+fastlane east
+```
+
 
 ----
 
-This README.md is auto-generated and will be re-generated every time to run [fastlane](https://fastlane.tools).
-More information about fastlane can be found on [https://fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [GitHub](https://github.com/fastlane/fastlane/tree/master/fastlane).
+This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
+The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -148,7 +148,7 @@ module Fastlane
         
         #####################################
         #
-        # html and plist uploading
+        # plist uploading
         #
         #####################################
         plist_url = self.upload_file(s3_client, s3_bucket, plist_file_name, plist_render, acl)
@@ -186,7 +186,7 @@ module Fastlane
 
         #####################################
         #
-        # html and plist uploading
+        # html uploading
         #
         #####################################
         html_url = self.upload_file(s3_client, s3_bucket, html_file_name, html_render, acl)

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -36,7 +36,6 @@ module Fastlane
 
         # Pulling parameters for other uses
         s3_region = params[:region]
-        s3_subdomain = params[:region] ? "s3-#{params[:region]}" : "s3"
         s3_access_key = params[:access_key]
         s3_secret_access_key = params[:secret_access_key]
         s3_bucket = params[:bucket]
@@ -60,13 +59,13 @@ module Fastlane
 
         s3_client = Aws::S3::Client.new
 
-        upload_ipa(s3_client, params, s3_region, s3_subdomain, s3_access_key, s3_secret_access_key, s3_bucket, ipa_file, dsym_file, s3_path, acl) if ipa_file.to_s.length > 0
-        upload_apk(s3_client, params, s3_region, s3_subdomain, s3_access_key, s3_secret_access_key, s3_bucket, apk_file, s3_path, acl) if apk_file.to_s.length > 0
+        upload_ipa(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, ipa_file, dsym_file, s3_path, acl) if ipa_file.to_s.length > 0
+        upload_apk(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, apk_file, s3_path, acl) if apk_file.to_s.length > 0
 
         return true
       end
 
-      def self.upload_ipa(s3_client, params, s3_region, s3_subdomain, s3_access_key, s3_secret_access_key, s3_bucket, ipa_file, dsym_file, s3_path, acl)
+      def self.upload_ipa(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, ipa_file, dsym_file, s3_path, acl)
 
         s3_path = "v{CFBundleShortVersionString}_b{CFBundleVersion}/" unless s3_path
 
@@ -122,7 +121,6 @@ module Fastlane
 
         # Creating plist and html names
         plist_file_name = "#{url_part}#{title.delete(' ')}.plist"
-        plist_url = "https://#{s3_bucket}.s3-#{s3_region}.amazonaws.com/#{plist_file_name}"
 
         html_file_name ||= "index.html"
 
@@ -147,6 +145,13 @@ module Fastlane
           bundle_version: bundle_version,
           title: title
         })
+        
+        #####################################
+        #
+        # html and plist uploading
+        #
+        #####################################
+        plist_url = self.upload_file(s3_client, s3_bucket, plist_file_name, plist_render, acl)
 
         # Creates html from template
         if html_template_path && File.exist?(html_template_path)
@@ -184,8 +189,6 @@ module Fastlane
         # html and plist uploading
         #
         #####################################
-
-        plist_url = self.upload_file(s3_client, s3_bucket, plist_file_name, plist_render, acl)
         html_url = self.upload_file(s3_client, s3_bucket, html_file_name, html_render, acl)
         version_url = self.upload_file(s3_client, s3_bucket, version_file_name, version_render, acl)
 
@@ -202,7 +205,7 @@ module Fastlane
         UI.success("Successfully uploaded ipa file to '#{Actions.lane_context[SharedValues::S3_IPA_OUTPUT_PATH]}'")
       end
 
-      def self.upload_apk(s3_client, params, s3_region, s3_subdomain, s3_access_key, s3_secret_access_key, s3_bucket, apk_file, s3_path, acl)
+      def self.upload_apk(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, apk_file, s3_path, acl)
         version = get_apk_version(apk_file)
 
         version_code = version[0]


### PR DESCRIPTION
- Removed `s3_subdomain` cause shouldn't be used
- Now using the url provided by the S3 SDK for the plist in the html

Hopefully helps #5 

### East
```sh
[07:15:35]: https://fastlane-plugin-s3-east.s3.amazonaws.com/v1.0.0_b21/BanditTheCat.plist
[07:15:35]: https://fastlane-plugin-s3-east.s3.amazonaws.com/index.html
```

### West
```
[07:18:05]: https://fastlane-plugin-s3-ios.s3-us-west-1.amazonaws.com/v1.0.0_b21/BanditTheCat.plist
[07:18:05]: https://fastlane-plugin-s3-ios.s3-us-west-1.amazonaws.com/index.html
```