### PR TITLE
Fix malformed itms-services: URL in HTML file.

### DIFF
--- a/lib/assets/s3_ios_html_template.erb
+++ b/lib/assets/s3_ios_html_template.erb
@@ -54,7 +54,7 @@
 
     <div class="oneRow">
       <span class="download" id="ios">
-        <a href="itms-services://?action=download-manifest&url=itms-services://?action=download-manifest&url=<%= plist_url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
+        <a href="itms-services://?action=download-manifest&url=<%= plist_url %>" id="text" class="btn btn-lg btn-default" onclick="document.getElementById('finished').id = '';">
           Install <%= title %> <%= bundle_version %>
         </a>
       </span>


### PR DESCRIPTION
Fixed the template for the generated .html metadata file so that the download URL has only a single download-manifest action in it. The previous version (perhaps a copy & paste error?) would fail to download on an iOS device.