### PR TITLE
Add the ability to pass an s3 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ aws_s3(
   bucket: ENV['S3_BUCKET'],                       # Required from user.
   region: ENV['S3_REGION'],                       # Required from user.
 
+  endpoint: 'https://s3-us-west-1.amazonaws.com', # Optional, for buckets that require a specific endpoint
   ipa: 'AppName.ipa',                             # Required (if not uploading an APK).
   dsym: 'AppName.app.dSYM.zip',                   # Optional is you use `ipa` to build.
 
   apk: 'AppName.apk',                             # Required (if not uploading an IPA).
-  
+
   app_directory: 'ios_or_android',                # Optional but nice if you want to put multiple apps in same bucket
 
   path: 'v{CFBundleShortVersionString}_b{CFBundleVersion}/', # This is actually the default.

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -25,6 +25,7 @@ module Fastlane
         params[:access_key] = config[:access_key]
         params[:secret_access_key] = config[:secret_access_key]
         params[:bucket] = config[:bucket]
+        params[:endpoint] = config[:endpoint]
         params[:region] = config[:region]
         params[:app_directory] = config[:app_directory]
         params[:acl] = config[:acl]
@@ -43,6 +44,7 @@ module Fastlane
         s3_access_key = params[:access_key]
         s3_secret_access_key = params[:secret_access_key]
         s3_bucket = params[:bucket]
+        s3_endpoint = params[:endpoint]
         apk_file = params[:apk]
         ipa_file = params[:ipa]
         dsym_file = params[:dsym]
@@ -61,7 +63,11 @@ module Fastlane
           credentials: Aws::Credentials.new(s3_access_key, s3_secret_access_key)
         })
 
-        s3_client = Aws::S3::Client.new
+        s3_client = if s3_endpoint
+                      Aws::S3::Client.new(endpoint: s3_endpoint)
+                    else
+                      Aws::S3::Client.new
+                    end
 
         upload_ipa(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, ipa_file, dsym_file, s3_path, acl) if ipa_file.to_s.length > 0
         upload_apk(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, apk_file, s3_path, acl) if apk_file.to_s.length > 0
@@ -477,7 +483,13 @@ module Fastlane
                                        description: "Uploaded object permissions e.g public_read (default), private, public_read_write, authenticated_read ",
                                        optional: true,
                                        default_value: "public-read"
-                                      )
+                                      ),
+          FastlaneCore::ConfigItem.new(key: :endpoint,
+                                       env_name: "S3_ENDPOINT",
+                                       description: "The base endpoint for your S3 bucket",
+                                       optional: true,
+                                       default_value: nil
+                                      ),
         ]
       end
 


### PR DESCRIPTION
Some private S3 buckets require that you use a specific endpoint when uploading, a param that is passed in to the Aws::S3::Client. This adds the ability to configure that endpoint.

Example error:
```xml
<Error>
<Code>PermanentRedirect</Code>
<Message>
  The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
</Message>
<Bucket>my_bucket</Bucket>
<Endpoint>
  my_bucket.s3-us-west-1.amazonaws.com
</Endpoint>
<RequestId>DBE8B5C6F29BA2DA</RequestId>
<HostId>
  Y11pifcXVFCDfuTqeVYQdhuD+NOHOYUkcFfKUOB8IcA05S50j+bhf6qT5ZS6yEYhPHG14m42bnY=
</HostId>
</Error>
```