### PR TITLE
set content type when uploading android APKs

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -388,12 +388,22 @@ module Fastlane
         end
 
         bucket = Aws::S3::Bucket.new(bucket_name, client: s3_client)
-        obj = bucket.put_object({
-          acl: acl,
-          key: file_name,
-          body: file_data
-        })
-
+        
+        if file_name.end_with?('apk')
+          obj = bucket.put_object({
+            acl: acl,
+            key: file_name,
+            body: file_data,
+            content_type: 'application/vnd.android.package-archive'
+          })
+        else
+          obj = bucket.put_object({
+            acl: acl,
+            key: file_name,
+            body: file_data
+          })
+        end
+        
         # When you enable versioning on a S3 bucket,
         # writing to an object will create an object version
         # instead of replacing the existing object.


### PR DESCRIPTION
This is needed for most android devices. When downloading the apk using chrome, if the file is served with wrong content type, it will not be possible to install it right from the Downloads folder.