### PR TITLE
switches to using Time.now since Date.current is not part of Ruby

### DIFF
--- a/lib/assets/s3_android_html_template.erb
+++ b/lib/assets/s3_android_html_template.erb
@@ -58,7 +58,7 @@
           Install <%= title %> <%= version_name %> (<%= version_code %>)
         </a>
         <br>
-        <p>Built on <%= Date.current.strftime('%a, %e %b %Y %H:%M %p') %></p>
+        <p>Built on <%= Time.now.strftime('%a, %e %b %Y %H:%M %p') %></p>
       </span>
 
       <!-- <span class="download" id="android">

--- a/lib/assets/s3_ios_html_template.erb
+++ b/lib/assets/s3_ios_html_template.erb
@@ -58,7 +58,7 @@
           Install <%= title %> <%= bundle_version %> (<%= build_num %>)
         </a>
         <br>
-        <p>Built on <%= Date.current.strftime('%a, %e %b %Y %H:%M %p') %></p>
+        <p>Built on <%= Time.now.strftime('%a, %e %b %Y %H:%M %p') %></p>
       </span>
 
       <!-- <span class="download" id="android">


### PR DESCRIPTION
Fixes #31 