### PR TITLE
sets the content-type (if known) for uploaded files

### DIFF
--- a/fastlane-plugin-aws_s3.gemspec
+++ b/fastlane-plugin-aws_s3.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk', '~> 2.3'
   spec.add_dependency 'apktools', '~> 0.7'
+  spec.add_dependency 'mime-types', '~> 3.1'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -3,6 +3,7 @@ require 'fastlane/erb_template_helper'
 include ERB::Util
 require 'ostruct'
 require 'cgi'
+require 'mime-types'
 
 module Fastlane
   module Actions
@@ -391,7 +392,8 @@ module Fastlane
         obj = bucket.put_object({
           acl: acl,
           key: file_name,
-          body: file_data
+          body: file_data,
+          content_type: MIME::Types.type_for(File.extname(file_name)).first.to_s
         })
 
         # When you enable versioning on a S3 bucket,


### PR DESCRIPTION
Solving #33 another way - from that PR:
> This is needed for most android devices. When downloading the apk using chrome, if the file is served with wrong content type, it will not be possible to install it right from the Downloads folder.

