### PR TITLE
fix: use Time class instead of Date class

### DIFF
--- a/lib/assets/s3_android_html_template.erb
+++ b/lib/assets/s3_android_html_template.erb
@@ -58,7 +58,7 @@
           Install <%= title %> <%= version_name %> (<%= version_code %>)
         </a>
         <br>
-        <p>Built on <%= Date.today.strftime('%a, %e %b %Y %H:%M %p') %></p>
+        <p>Built on <%= Time.now.strftime('%a, %e %b %Y %H:%M %p') %></p>
       </span>
 
       <!-- <span class="download" id="android">


### PR DESCRIPTION
Previously I made a mistake by using the `Date` class to produce a time string, resulting in a persistent `00:00` timing.

Using `Time` class now to solve this.