### PR TITLE
makes html_template_params also be passed to the version template

### DIFF
--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -217,7 +217,7 @@ module Fastlane
           build_num: build_num,
           bundle_version: bundle_version,
           full_version: full_version
-        })
+        }.merge(html_template_params))
 
         #####################################
         #
@@ -341,7 +341,7 @@ module Fastlane
           version_code: version_code,
           version_name: version_name,
           full_version: "#{version_code}_#{version_name}"
-        })
+        }.merge(html_template_params))
 
         #####################################
         #


### PR DESCRIPTION
no reason not to pass the html template params to the version template as well. The param name is now a bit of a misnomer, but likely not work changing.