### PR TITLE
Add the ability to upload any files to s3

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,6 +63,31 @@ lane :east do
   )
 end
 
+lane :files_no_path do
+  aws_s3(
+    bucket: 'fastlane-plugin-s3-east',
+    region: 'us-east-1',
+    files: [
+      './fastlane/testfile1.txt',
+      './fastlane/testfile2.txt',
+    ],
+    folder: './fastlane/testdir1'
+  )
+end
+
+lane :files do
+  aws_s3(
+    bucket: 'fastlane-plugin-s3-east',
+    region: 'us-east-1',
+    path: 'dafiles',
+    files: [
+      './fastlane/testfile1.txt',
+      './fastlane/testfile2.txt',
+    ],
+    folder: './fastlane/testdir1'
+  )
+end
+
 after_all do
   puts Action.lane_context[SharedValues::S3_PLIST_OUTPUT_PATH]
   puts Actions.lane_context[SharedValues::S3_HTML_OUTPUT_PATH]

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -64,6 +64,16 @@ fastlane apk2
 fastlane east
 ```
 
+### files_no_path
+```
+fastlane files_no_path
+```
+
+### files
+```
+fastlane files
+```
+
 
 ----
 

--- a/fastlane/testdir1/testfile1_dir1.txt
+++ b/fastlane/testdir1/testfile1_dir1.txt
@@ -1,0 +1,1 @@
+testfile1_dir1

--- a/fastlane/testdir1/testfile2_dir1.txt
+++ b/fastlane/testdir1/testfile2_dir1.txt
@@ -1,0 +1,1 @@
+testfile2_dir1

--- a/fastlane/testdir2/testfile1_dir2.txt
+++ b/fastlane/testdir2/testfile1_dir2.txt
@@ -1,0 +1,1 @@
+testfile1_dir2

--- a/fastlane/testdir2/testfile2_dir2.txt
+++ b/fastlane/testdir2/testfile2_dir2.txt
@@ -1,0 +1,1 @@
+testfile2_dir2

--- a/fastlane/testfile1.txt
+++ b/fastlane/testfile1.txt
@@ -1,0 +1,1 @@
+testfile1

--- a/fastlane/testfile2.txt
+++ b/fastlane/testfile2.txt
@@ -1,0 +1,1 @@
+testfile2

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -74,7 +74,7 @@ module Fastlane
 
         unless s3_profile
           UI.user_error!("No S3 access key given, pass using `access_key: 'key'` (or use `aws_profile: 'profile'`)") unless s3_access_key.to_s.length > 0
-          UI.user_error!("No S3 secret access key given, pass using `secret_access_key: 'secret key'` (or use `aws_profile: 'profile'`") unless s3_secret_access_key.to_s.length > 0
+          UI.user_error!("No S3 secret access key given, pass using `secret_access_key: 'secret key'` (or use `aws_profile: 'profile'`)") unless s3_secret_access_key.to_s.length > 0
         end
         UI.user_error!("No S3 bucket given, pass using `bucket: 'bucket'`") unless s3_bucket.to_s.length > 0
         UI.user_error!("No IPA, APK file, folder or files paths given, pass using `ipa: 'ipa path'` or `apk: 'apk path'` or `folder: 'folder path' or files: [`file path1`, `file path 2`]") if ipa_file.to_s.length == 0 && apk_file.to_s.length == 0 && files.to_a.count == 0 && folder.to_s.length == 0
@@ -443,7 +443,7 @@ module Fastlane
 
       def self.upload_files(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, files, s3_path, acl, server_side_encryption)
 
-        s3_path = "/files/" unless s3_path
+        s3_path = "files" unless s3_path
 
         app_directory = params[:app_directory]
         url_part = s3_path
@@ -462,6 +462,8 @@ module Fastlane
       end
 
       def self.upload_folder(s3_client, params, s3_region, s3_access_key, s3_secret_access_key, s3_bucket, folder, s3_path, acl, server_side_encryption)
+
+        s3_path = "files" unless s3_path
 
         s3_path = s3_path.to_s + '/' + File.basename(folder)
         url_part = s3_path

--- a/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
+++ b/lib/fastlane/plugin/aws_s3/actions/aws_s3_action.rb
@@ -447,8 +447,9 @@ module Fastlane
         files.each do |file|
           file_basename = File.basename(file)
           file_data = File.open(file, 'rb')
+          file_name = url_part + '/' + file_basename
 
-          file_url = self.upload_file(s3_client, s3_bucket, app_directory, file_basename, file_data, acl, server_side_encryption)
+          file_url = self.upload_file(s3_client, s3_bucket, app_directory, file_name, file_data, acl, server_side_encryption)
 
           # Setting action and environment variables
           Actions.lane_context[SharedValues::S3_FILES_OUTPUT_PATHS] << file_url


### PR DESCRIPTION
# Description

This PR add the ability to upload just any file to S3, along with an IPA/APK or not.

# Motivation

Uploading stuff to S3 is more and more common. Typically upload test screenshots after a snapshot run is a common usecase.
To avoid making another plugin (and another action i could not name!) and handling all the s3 auth complexity again: add the ability to pass files to upload to s3 along with the ipa file (or not)

May solve https://github.com/joshdholtz/fastlane-plugin-s3/issues/32